### PR TITLE
Use request-promise for config http requests

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -3,7 +3,7 @@ var zlib = require('zlib');
 var fs = require('fs');
 var google = require('googleapis');
 
-var PROJECT_ID = 'gh-quickstarter-278bf';
+var PROJECT_ID = 'PROJECT_ID';
 var HOST = 'https://firebaseremoteconfig.googleapis.com';
 var PATH = '/v1/projects/' + PROJECT_ID + '/remoteConfig';
 var SCOPES = ['https://www.googleapis.com/auth/firebase.remoteconfig'];

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,4 @@
 var rp = require('request-promise');
-var zlib = require('zlib');
 var fs = require('fs');
 var google = require('googleapis');
 

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "google-auth-library": "^0.10.0",
-    "googleapis": "^20.1.0"
+    "googleapis": "^20.1.0",
+    "request-promise": "^4.2.2",
+    "request": "^2.88.0"
   }
 }


### PR DESCRIPTION
With `request-promise` exposing response features like errors are easier. So switching from `https` to `request-promise` for http requests in the config sample.