### PR TITLE
Temporarily hard-code an ipv4 address to bypass a gRPC backoff issue

### DIFF
--- a/firestore-emulator/javascript-quickstart/package.json
+++ b/firestore-emulator/javascript-quickstart/package.json
@@ -4,7 +4,7 @@
   "description": "Cloud Firestore emulator testing",
   "scripts": {
     "format": "prettier --write **/*.js",
-    "test": "mocha"
+    "test": "FIREBASE_FIRESTORE_EMULATOR_ADDRESS='127.0.0.1:8080' mocha"
   },
   "devDependencies": {
     "@firebase/testing": "0.3.3",

--- a/firestore-emulator/typescript-quickstart/package.json
+++ b/firestore-emulator/typescript-quickstart/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "format": "prettier --write **/*.ts",
     "pretest": "tsc",
-    "test": "mocha"
+    "test": "FIREBASE_FIRESTORE_EMULATOR_ADDRESS='127.0.0.1:8080' mocha"
   },
   "devDependencies": {
     "@firebase/testing": "0.3.3",


### PR DESCRIPTION
This will work around https://github.com/firebase/firebase-js-sdk/issues/1396 until `@firebase/testing@0.3.4` is released to fix this issue