### PR TITLE
Updated emulator quickstarts

### DIFF
--- a/database-emulator/javascript-quickstart/README.md
+++ b/database-emulator/javascript-quickstart/README.md
@@ -27,40 +27,8 @@ To run the tests, execute
 ```
 npm test
 ```
-which runs all the tests in the `tests/` directory. At
-the beginning, you should see 3 tests pass and 1 tests fail.
+which runs all the tests in the `tests/` directory.
 
-```
-  profile read rules
-    ✓ should allow anyone to read profiles
-    1) should only allow users to modify their own profiles
-
-  room creation
-    ✓ should require the user creating a room to be its owner
-
-  room members
-    ✓ must be added by the room owner
-
-
-  3 passing
-  1 failing
-```
-
-## Making the tests pass
-
-The tests fail because they expect the rules to block unauthorized writes to a location. To fix
-this, go to the database.rules.json and uncomment the rule on line 6:
-
-```
-".write": "auth.uid == $userId"
-```
-
-If we re-run the tests now, they should all pass.
-```
-npm test
-```
-
-should give you output like
 ```
   profile read rules
     ✓ should allow anyone to read profiles

--- a/database-emulator/javascript-quickstart/database.rules.json
+++ b/database-emulator/javascript-quickstart/database.rules.json
@@ -3,7 +3,7 @@
     "users": {
       "$userId": {
         ".read": true,
-        // ".write": "auth.uid == $userId"
+        ".write": "auth.uid == $userId"
       }
     },
     "rooms": {

--- a/database-emulator/javascript-quickstart/package.json
+++ b/database-emulator/javascript-quickstart/package.json
@@ -3,13 +3,13 @@
   "version": "1.0.1",
   "description": "Real Time Database emulator testing",
   "scripts": {
-    "pretest": "eslint test/*.js",
+    "format": "prettier --write **/*.js",
     "test": "mocha"
   },
   "devDependencies": {
-    "@firebase/testing": "0.3.0",
-    "eslint": "5.7.0",
-    "eslint-config-google": "0.11.0",
-    "mocha": "4.1.0"
+    "@firebase/testing": "0.3.3",
+    "filesystem": "1.0.1",
+    "mocha": "5.2.0",
+    "prettier": "1.15.2"
   }
 }

--- a/database-emulator/javascript-quickstart/test/test.js
+++ b/database-emulator/javascript-quickstart/test/test.js
@@ -1,15 +1,15 @@
-const firebase = require('@firebase/testing');
-const fs = require('fs');
+const firebase = require("@firebase/testing");
+const fs = require("fs");
 
 /*
  * ============
  *    Setup
  * ============
  */
-const databaseName = 'database-emulator-example';
-const coverageUrlBase = 'http://localhost:9000/.inspect/coverage?ns=';
+const databaseName = "database-emulator-example";
+const coverageUrl = `http://localhost:9000/.inspect/coverage?ns=${databaseName}`;
 
-const rules = fs.readFileSync('database.rules.json', 'utf8');
+const rules = fs.readFileSync("database.rules.json", "utf8");
 
 /**
  * Creates a new app with authentication data matching the input.
@@ -18,10 +18,12 @@ const rules = fs.readFileSync('database.rules.json', 'utf8');
  * @return {object} the app.
  */
 function authedApp(auth) {
-  return firebase.initializeTestApp({
-    databaseName: databaseName,
-    auth: auth,
-  }).database();
+  return firebase
+    .initializeTestApp({
+      databaseName: databaseName,
+      auth: auth
+    })
+    .database();
 }
 
 /**
@@ -30,7 +32,7 @@ function authedApp(auth) {
  * @return {object} the app.
  */
 function adminApp() {
-  return firebase.initializeAdminApp({databaseName: databaseName}).database();
+  return firebase.initializeAdminApp({ databaseName: databaseName }).database();
 }
 
 /*
@@ -42,81 +44,102 @@ before(async () => {
   // Set database rules before running these tests
   await firebase.loadDatabaseRules({
     databaseName: databaseName,
-    rules: rules,
+    rules: rules
   });
 });
 
 beforeEach(async () => {
   // Clear the database between tests
-  await adminApp().ref().set(null);
+  await adminApp()
+    .ref()
+    .set(null);
 });
 
 after(async () => {
   // Close any open apps
-  await Promise.all(firebase.apps().map((app) => app.delete()));
+  await Promise.all(firebase.apps().map(app => app.delete()));
 });
 
-describe('profile read rules', () => {
-  it('should allow anyone to read profiles', async () => {
-    const alice = authedApp({uid: 'alice'});
-    const bob = authedApp({uid: 'bob'});
+describe("profile read rules", () => {
+  it("should allow anyone to read profiles", async () => {
+    const alice = authedApp({ uid: "alice" });
+    const bob = authedApp({ uid: "bob" });
     const noone = authedApp(null);
 
-    await adminApp().ref('users/alice').set({
-      name: 'Alice',
-      profilePicture: 'http://cool_photos/alice.jpg',
-    });
+    await adminApp()
+      .ref("users/alice")
+      .set({
+        name: "Alice",
+        profilePicture: "http://cool_photos/alice.jpg"
+      });
 
-    await firebase.assertSucceeds(alice.ref('users/alice').once('value'));
-    await firebase.assertSucceeds(bob.ref('users/alice').once('value'));
-    await firebase.assertSucceeds(noone.ref('users/alice').once('value'));
+    await firebase.assertSucceeds(alice.ref("users/alice").once("value"));
+    await firebase.assertSucceeds(bob.ref("users/alice").once("value"));
+    await firebase.assertSucceeds(noone.ref("users/alice").once("value"));
   });
 
-  it('should only allow users to modify their own profiles', async () => {
-    const alice = authedApp({uid: 'alice'});
-    const bob = authedApp({uid: 'bob'});
+  it("should only allow users to modify their own profiles", async () => {
+    const alice = authedApp({ uid: "alice" });
+    const bob = authedApp({ uid: "bob" });
     const noone = authedApp(null);
 
-    await firebase.assertSucceeds(alice.ref('users/alice').update({
-      'favorite_color': 'blue',
-    }));
-    await firebase.assertFails(bob.ref('users/alice').update({
-      'favorite_color': 'red',
-    }));
-    await firebase.assertFails(noone.ref('users/alice').update({
-      'favorite_color': 'orange',
-    }));
+    await firebase.assertSucceeds(
+      alice.ref("users/alice").update({
+        favorite_color: "blue"
+      })
+    );
+    await firebase.assertFails(
+      bob.ref("users/alice").update({
+        favorite_color: "red"
+      })
+    );
+    await firebase.assertFails(
+      noone.ref("users/alice").update({
+        favorite_color: "orange"
+      })
+    );
   });
 });
 
-describe('room creation', () => {
-  it('should require the user creating a room to be its owner', async () => {
-    const alice = authedApp({uid: 'alice'});
+describe("room creation", () => {
+  it("should require the user creating a room to be its owner", async () => {
+    const alice = authedApp({ uid: "alice" });
 
     // should not be able to create room owned by another user
-    await firebase.assertFails(alice.ref('rooms/room1').set({owner: 'bob'}));
+    await firebase.assertFails(alice.ref("rooms/room1").set({ owner: "bob" }));
     // should not be able to create room with no owner
-    await firebase.assertFails(alice.ref('rooms/room1').set({members: {'alice': true}}));
+    await firebase.assertFails(
+      alice.ref("rooms/room1").set({ members: { alice: true } })
+    );
     // alice should be allowed to create a room she owns
-    await firebase.assertSucceeds(alice.ref('rooms/room1').set({owner: 'alice'}));
+    await firebase.assertSucceeds(
+      alice.ref("rooms/room1").set({ owner: "alice" })
+    );
   });
 });
 
-describe('room members', () => {
-  it('must be added by the room owner', async () => {
-    const ownerId = 'room_owner';
-    const owner = authedApp({uid: ownerId});
-    await owner.ref('rooms/room2').set({owner: ownerId});
+describe("room members", () => {
+  it("must be added by the room owner", async () => {
+    const ownerId = "room_owner";
+    const owner = authedApp({ uid: ownerId });
+    await owner.ref("rooms/room2").set({ owner: ownerId });
 
-    const aliceId = 'alice';
-    const alice = authedApp({uid: aliceId});
+    const aliceId = "alice";
+    const alice = authedApp({ uid: aliceId });
     // alice cannot add random people to a room
-    await firebase.assertFails(alice.ref('rooms/room2/members/rando').set(true));
+    await firebase.assertFails(
+      alice.ref("rooms/room2/members/rando").set(true)
+    );
     // alice cannot add herself to a room
-    await firebase.assertFails(alice.ref('rooms/room2/members/alice').set(true));
+    await firebase.assertFails(
+      alice.ref("rooms/room2/members/alice").set(true)
+    );
     // the owner can add alice to a room
-    await firebase.assertSucceeds(owner.ref('rooms/room2/members/alice').set(true));
+    await firebase.assertSucceeds(
+      owner.ref("rooms/room2/members/alice").set(true)
+    );
   });
 });
 
-console.log('View rule coverage information at ' + coverageUrlBase + databaseName);
+process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));
+

--- a/database-emulator/javascript-quickstart/test/test.js
+++ b/database-emulator/javascript-quickstart/test/test.js
@@ -141,5 +141,6 @@ describe("room members", () => {
   });
 });
 
-process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));
-
+process.on("exit", () =>
+  console.log(`View rule coverage information at ${coverageUrl}\n`)
+);

--- a/database-emulator/javascript-quickstart/test/test.js
+++ b/database-emulator/javascript-quickstart/test/test.js
@@ -18,12 +18,7 @@ const rules = fs.readFileSync("database.rules.json", "utf8");
  * @return {object} the app.
  */
 function authedApp(auth) {
-  return firebase
-    .initializeTestApp({
-      databaseName: databaseName,
-      auth: auth
-    })
-    .database();
+  return firebase.initializeTestApp({ databaseName, auth }).database();
 }
 
 /**
@@ -32,7 +27,7 @@ function authedApp(auth) {
  * @return {object} the app.
  */
 function adminApp() {
-  return firebase.initializeAdminApp({ databaseName: databaseName }).database();
+  return firebase.initializeAdminApp({ databaseName }).database();
 }
 
 /*
@@ -43,7 +38,7 @@ function adminApp() {
 before(async () => {
   // Set database rules before running these tests
   await firebase.loadDatabaseRules({
-    databaseName: databaseName,
+    databaseName,
     rules: rules
   });
 });
@@ -58,6 +53,7 @@ beforeEach(async () => {
 after(async () => {
   // Close any open apps
   await Promise.all(firebase.apps().map(app => app.delete()));
+  console.log(`View rule coverage information at ${coverageUrl}\n`);
 });
 
 describe("profile read rules", () => {
@@ -140,7 +136,3 @@ describe("room members", () => {
     );
   });
 });
-
-process.on("exit", () =>
-  console.log(`View rule coverage information at ${coverageUrl}\n`)
-);

--- a/database-emulator/typescript-quickstart/README.md
+++ b/database-emulator/typescript-quickstart/README.md
@@ -27,40 +27,8 @@ To run the tests, execute
 ```
 npm test
 ```
-which runs all the tests in the `tests/` directory. At
-the beginning, you should see 3 tests pass and 1 tests fail.
+which runs all the tests in the `tests/` directory.
 
-```
-  profile read rules
-    ✓ should allow anyone to read profiles
-    1) should only allow users to modify their own profiles
-
-  room creation
-    ✓ should require the user creating a room to be its owner
-
-  room members
-    ✓ must be added by the room owner
-
-
-  3 passing
-  1 failing
-```
-
-## Making the tests pass
-
-The tests fail because they expect the rules to block unauthorized writes to a location. To fix
-this, go to the database.rules.json and uncomment the rule on line 6:
-
-```
-".write": "auth.uid == $userId"
-```
-
-If we re-run the tests now, they should all pass.
-```
-npm test
-```
-
-should give you output like
 ```
   profile read rules
     ✓ should allow anyone to read profiles

--- a/database-emulator/typescript-quickstart/database.rules.json
+++ b/database-emulator/typescript-quickstart/database.rules.json
@@ -3,7 +3,7 @@
     "users": {
       "$userId": {
         ".read": true,
-        // ".write": "auth.uid == $userId"
+        ".write": "auth.uid == $userId"
       }
     },
     "rooms": {

--- a/database-emulator/typescript-quickstart/package.json
+++ b/database-emulator/typescript-quickstart/package.json
@@ -3,22 +3,19 @@
   "version": "1.0.1",
   "description": "Real Time Database emulator testing, with TypeScript",
   "scripts": {
-    "pretest": "eslint test/*.ts && tsc",
+    "format": "prettier --write **/*.ts",
+    "pretest": "tsc",
     "test": "mocha"
   },
   "devDependencies": {
-    "@firebase/testing": "0.3.0",
+    "@firebase/testing": "0.3.3",
     "@types/mocha": "5.2.5",
-    "eslint": "5.7.0",
-    "eslint-config-google": "0.11.0",
+    "filesystem": "1.0.1",
     "mocha": "5.2.0",
     "mocha-typescript": "1.1.17",
+    "prettier": "1.15.2",
     "source-map-support": "0.5.9",
     "ts-node": "7.0.1",
-    "typescript": "3.1.3",
-    "typescript-eslint-parser": "20.0.0"
-  },
-  "dependencies": {
-    "firebase": "^5.5.5"
+    "typescript": "3.1.3"
   }
 }

--- a/database-emulator/typescript-quickstart/test/test.ts
+++ b/database-emulator/typescript-quickstart/test/test.ts
@@ -19,12 +19,7 @@ const rules = fs.readFileSync("database.rules.json", "utf8");
  * @return {object} the app.
  */
 function authedApp(auth) {
-  return firebase
-    .initializeTestApp({
-      databaseName: databaseName,
-      auth: auth
-    })
-    .database();
+  return firebase.initializeTestApp({ databaseName, auth }).database();
 }
 
 /**
@@ -33,7 +28,7 @@ function authedApp(auth) {
  * @return {object} the app.
  */
 function adminApp() {
-  return firebase.initializeAdminApp({ databaseName: databaseName }).database();
+  return firebase.initializeAdminApp({ databaseName }).database();
 }
 
 /*
@@ -45,7 +40,7 @@ class TestingBase {
   async before() {
     // Set database rules before running these tests
     await firebase.loadDatabaseRules({
-      databaseName: databaseName,
+      databaseName,
       rules: rules
     });
   }
@@ -60,6 +55,7 @@ class TestingBase {
   async after() {
     // Close any open apps
     await Promise.all(firebase.apps().map(app => app.delete()));
+    console.log(`View rule coverage information at ${coverageUrl}\n`);
   }
 }
 
@@ -150,7 +146,3 @@ class RoomMembers extends TestingBase {
     );
   }
 }
-
-process.on("exit", () =>
-  console.log(`View rule coverage information at ${coverageUrl}\n`)
-);

--- a/database-emulator/typescript-quickstart/test/test.ts
+++ b/database-emulator/typescript-quickstart/test/test.ts
@@ -1,4 +1,3 @@
-// Reference mocha-typescript's global definitions:
 /// <reference path='../node_modules/mocha-typescript/globals.d.ts' />
 import * as firebase from "@firebase/testing";
 import * as fs from "fs";
@@ -152,4 +151,6 @@ class RoomMembers extends TestingBase {
   }
 }
 
-process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));
+process.on("exit", () =>
+  console.log(`View rule coverage information at ${coverageUrl}\n`)
+);

--- a/database-emulator/typescript-quickstart/test/test.ts
+++ b/database-emulator/typescript-quickstart/test/test.ts
@@ -1,30 +1,31 @@
 // Reference mocha-typescript's global definitions:
-// eslint-disable-next-line spaced-comment
 /// <reference path='../node_modules/mocha-typescript/globals.d.ts' />
-import * as firebase from '@firebase/testing';
-import * as fs from 'fs';
+import * as firebase from "@firebase/testing";
+import * as fs from "fs";
 
 /*
  * ============
  *    Setup
  * ============
  */
-const databaseName = 'database-emulator-example';
-const coverageUrlBase = 'http://localhost:9000/.inspect/coverage?ns=';
+const databaseName = "database-emulator-example";
+const coverageUrl = `http://localhost:9000/.inspect/coverage?ns=${databaseName}`;
 
-const rules = fs.readFileSync('database.rules.json', 'utf8');
+const rules = fs.readFileSync("database.rules.json", "utf8");
 
 /**
-* Creates a new app with authentication data matching the input.
-*
-* @param {object} auth the object to use for authentication (typically {uid: some-uid})
-* @return {object} the app.
-*/
+ * Creates a new app with authentication data matching the input.
+ *
+ * @param {object} auth the object to use for authentication (typically {uid: some-uid})
+ * @return {object} the app.
+ */
 function authedApp(auth) {
-  return firebase.initializeTestApp({
-    databaseName: databaseName,
-    auth: auth,
-  }).database();
+  return firebase
+    .initializeTestApp({
+      databaseName: databaseName,
+      auth: auth
+    })
+    .database();
 }
 
 /**
@@ -33,7 +34,7 @@ function authedApp(auth) {
  * @return {object} the app.
  */
 function adminApp() {
-  return firebase.initializeAdminApp({databaseName: databaseName}).database();
+  return firebase.initializeAdminApp({ databaseName: databaseName }).database();
 }
 
 /*
@@ -41,92 +42,114 @@ function adminApp() {
  *  Test Cases
  * ============
  */
-/* eslint-disable require-jsdoc */
 class TestingBase {
   async before() {
     // Set database rules before running these tests
     await firebase.loadDatabaseRules({
       databaseName: databaseName,
-      rules: rules,
+      rules: rules
     });
   }
 
   async beforeEach() {
     // Clear the database between tests
-    await adminApp().ref().set(null);
+    await adminApp()
+      .ref()
+      .set(null);
   }
 
   async after() {
     // Close any open apps
-    await Promise.all(firebase.apps().map((app) => app.delete()));
+    await Promise.all(firebase.apps().map(app => app.delete()));
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-@suite class ProfileReadRules extends TestingBase {
-  @test async 'should allow anyone to read profiles'() {
-    const alice = authedApp({uid: 'alice'});
-    const bob = authedApp({uid: 'bob'});
+@suite
+class ProfileReadRules extends TestingBase {
+  @test
+  async "should allow anyone to read profiles"() {
+    const alice = authedApp({ uid: "alice" });
+    const bob = authedApp({ uid: "bob" });
     const noone = authedApp(null);
 
-    await adminApp().ref('users/alice').set({
-      name: 'Alice',
-      profilePicture: 'http://cool_photos/alice.jpg',
-    });
+    await adminApp()
+      .ref("users/alice")
+      .set({
+        name: "Alice",
+        profilePicture: "http://cool_photos/alice.jpg"
+      });
 
-    await firebase.assertSucceeds(alice.ref('users/alice').once('value'));
-    await firebase.assertSucceeds(bob.ref('users/alice').once('value'));
-    await firebase.assertSucceeds(noone.ref('users/alice').once('value'));
+    await firebase.assertSucceeds(alice.ref("users/alice").once("value"));
+    await firebase.assertSucceeds(bob.ref("users/alice").once("value"));
+    await firebase.assertSucceeds(noone.ref("users/alice").once("value"));
   }
 
-  @test async 'should only allow users to modify their own profiles'() {
-    const alice = authedApp({uid: 'alice'});
-    const bob = authedApp({uid: 'bob'});
+  @test
+  async "should only allow users to modify their own profiles"() {
+    const alice = authedApp({ uid: "alice" });
+    const bob = authedApp({ uid: "bob" });
     const noone = authedApp(null);
 
-    await firebase.assertSucceeds(alice.ref('users/alice').update({
-      'favorite_color': 'blue',
-    }));
-    await firebase.assertFails(bob.ref('users/alice').update({
-      'favorite_color': 'red',
-    }));
-    await firebase.assertFails(noone.ref('users/alice').update({
-      'favorite_color': 'orange',
-    }));
+    await firebase.assertSucceeds(
+      alice.ref("users/alice").update({
+        favorite_color: "blue"
+      })
+    );
+    await firebase.assertFails(
+      bob.ref("users/alice").update({
+        favorite_color: "red"
+      })
+    );
+    await firebase.assertFails(
+      noone.ref("users/alice").update({
+        favorite_color: "orange"
+      })
+    );
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-@suite class RoomCreation extends TestingBase {
-  @test async 'should require the user creating a room to be its owner'() {
-    const alice = authedApp({uid: 'alice'});
+@suite
+class RoomCreation extends TestingBase {
+  @test
+  async "should require the user creating a room to be its owner"() {
+    const alice = authedApp({ uid: "alice" });
 
     // should not be able to create room owned by another user
-    await firebase.assertFails(alice.ref('rooms/room1').set({owner: 'bob'}));
+    await firebase.assertFails(alice.ref("rooms/room1").set({ owner: "bob" }));
     // should not be able to create room with no owner
-    await firebase.assertFails(alice.ref('rooms/room1').set({members: {'alice': true}}));
+    await firebase.assertFails(
+      alice.ref("rooms/room1").set({ members: { alice: true } })
+    );
     // alice should be allowed to create a room she owns
-    await firebase.assertSucceeds(alice.ref('rooms/room1').set({owner: 'alice'}));
+    await firebase.assertSucceeds(
+      alice.ref("rooms/room1").set({ owner: "alice" })
+    );
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-@suite class RoomMembers extends TestingBase {
-  @test async 'must be added by the room owner'() {
-    const ownerId = 'room_owner';
-    const owner = authedApp({uid: ownerId});
-    await owner.ref('rooms/room2').set({owner: ownerId});
+@suite
+class RoomMembers extends TestingBase {
+  @test
+  async "must be added by the room owner"() {
+    const ownerId = "room_owner";
+    const owner = authedApp({ uid: ownerId });
+    await owner.ref("rooms/room2").set({ owner: ownerId });
 
-    const aliceId = 'alice';
-    const alice = authedApp({uid: aliceId});
+    const aliceId = "alice";
+    const alice = authedApp({ uid: aliceId });
     // alice cannot add random people to a room
-    await firebase.assertFails(alice.ref('rooms/room2/members/rando').set(true));
+    await firebase.assertFails(
+      alice.ref("rooms/room2/members/rando").set(true)
+    );
     // alice cannot add herself to a room
-    await firebase.assertFails(alice.ref('rooms/room2/members/alice').set(true));
+    await firebase.assertFails(
+      alice.ref("rooms/room2/members/alice").set(true)
+    );
     // the owner can add alice to a room
-    await firebase.assertSucceeds(owner.ref('rooms/room2/members/alice').set(true));
+    await firebase.assertSucceeds(
+      owner.ref("rooms/room2/members/alice").set(true)
+    );
   }
 }
-/* eslint-enable require-jsdoc */
 
-console.log('View rule coverage information at ' + coverageUrlBase + databaseName);
+process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));

--- a/firestore-emulator/javascript-quickstart/test/test.js
+++ b/firestore-emulator/javascript-quickstart/test/test.js
@@ -19,10 +19,7 @@ const rules = fs.readFileSync("firestore.rules", "utf8");
  */
 function authedApp(auth) {
   return firebase
-    .initializeTestApp({
-      projectId: projectName,
-      auth: auth
-    })
+    .initializeTestApp({ projectId: projectName, auth })
     .firestore();
 }
 
@@ -47,6 +44,7 @@ before(async () => {
 
 after(async () => {
   await Promise.all(firebase.apps().map(app => app.delete()));
+  console.log(`View rule coverage information at ${coverageUrl}\n`);
 });
 
 describe("My app", () => {
@@ -143,7 +141,3 @@ describe("My app", () => {
     );
   });
 });
-
-process.on("exit", () =>
-  console.log(`View rule coverage information at ${coverageUrl}\n`)
-);

--- a/firestore-emulator/javascript-quickstart/test/test.js
+++ b/firestore-emulator/javascript-quickstart/test/test.js
@@ -144,4 +144,6 @@ describe("My app", () => {
   });
 });
 
-process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));
+process.on("exit", () =>
+  console.log(`View rule coverage information at ${coverageUrl}\n`)
+);

--- a/firestore-emulator/javascript-quickstart/test/test.js
+++ b/firestore-emulator/javascript-quickstart/test/test.js
@@ -6,35 +6,10 @@ const fs = require("fs");
  *    Setup
  * ============
  */
-const projectIdBase = "firestore-emulator-example-" + Date.now();
+const projectName = "firestore-emulator-example";
+const coverageUrl = `http://localhost:8080/emulator/v1/projects/${projectName}:ruleCoverage.html`;
 
 const rules = fs.readFileSync("firestore.rules", "utf8");
-
-// Run each test in its own project id to make it independent.
-let testNumber = 0;
-
-/**
- * Returns the project ID for the current test
- *
- * @return {string} the project ID for the current test.
- */
-function getProjectId() {
-  return `${projectIdBase}-${testNumber}`;
-}
-
-beforeEach(async () => {
-  // Create new project ID for each test.
-  testNumber++;
-  await firebase.loadFirestoreRules({
-    projectId: getProjectId(),
-    rules: rules
-  });
-});
-
-after(async () => {
-  await Promise.all(firebase.apps().map(app => app.delete()));
-});
-
 
 /**
  * Creates a new app with authentication data matching the input.
@@ -45,7 +20,7 @@ after(async () => {
 function authedApp(auth) {
   return firebase
     .initializeTestApp({
-      projectId: getProjectId(),
+      projectId: projectName,
       auth: auth
     })
     .firestore();
@@ -56,6 +31,24 @@ function authedApp(auth) {
  *  Test Cases
  * ============
  */
+beforeEach(async () => {
+  // Clear the database between tests
+  await firebase.clearFirestoreData({
+    projectId: projectName
+  });
+});
+
+before(async () => {
+  await firebase.loadFirestoreRules({
+    projectId: projectName,
+    rules: rules
+  });
+});
+
+after(async () => {
+  await Promise.all(firebase.apps().map(app => app.delete()));
+});
+
 describe("My app", () => {
   it("require users to log in before creating a profile", async () => {
     const db = authedApp(null);
@@ -150,3 +143,5 @@ describe("My app", () => {
     );
   });
 });
+
+process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));

--- a/firestore-emulator/typescript-quickstart/test/test.ts
+++ b/firestore-emulator/typescript-quickstart/test/test.ts
@@ -20,10 +20,7 @@ const rules = fs.readFileSync("firestore.rules", "utf8");
  */
 function authedApp(auth) {
   return firebase
-    .initializeTestApp({
-      projectId: projectName,
-      auth: auth
-    })
+    .initializeTestApp({ projectId: projectName, auth })
     .firestore();
 }
 
@@ -49,6 +46,7 @@ class TestingBase {
 
   async after() {
     await Promise.all(firebase.apps().map(app => app.delete()));
+    console.log(`View rule coverage information at ${coverageUrl}\n`);
   }
 }
 
@@ -154,7 +152,3 @@ class MyApp extends TestingBase {
     );
   }
 }
-
-process.on("exit", () =>
-  console.log(`View rule coverage information at ${coverageUrl}\n`)
-);

--- a/firestore-emulator/typescript-quickstart/test/test.ts
+++ b/firestore-emulator/typescript-quickstart/test/test.ts
@@ -155,4 +155,6 @@ class MyApp extends TestingBase {
   }
 }
 
-process.on('exit', () => console.log(`View rule coverage information at ${coverageUrl}\n`));
+process.on("exit", () =>
+  console.log(`View rule coverage information at ${coverageUrl}\n`)
+);


### PR DESCRIPTION
*** Not an urgent PR (reviewers take their time) ***

This PR has functionality that depends on the latest version of the Firestore emulator. It will not be merged until the CLI and SDK are updated with this dependency

Changes:
- Made all emulator quickstarts use the same formatting engine (prettier)
- ALL Quickstarts print the rulecoverage notice at the BOTTOM
- Quickstarts don't require any work to get the tests to pass :(
- Firestore quickstarts have all tests run on the same projectId and use the clearFirestoreData() function.