### PR TITLE
Use default application credential

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -15,7 +15,7 @@ Getting started
 
 1. [Add Firebase to your Android Project](https://firebase.google.com/docs/android/setup).
 2. Create a service account as described in [Adding Firebase to your Server](https://firebase.google.com/docs/admin/setup) and download the JSON file.
-  - Copy the private key JSON file to this folder and rename it to `service-account.json`.
+  - Set `GOOGLE_APPLICATION_CREDENTIALS` environment variable to path of downloaded credential file.
 3. Change the `PROJECT_ID` variable in `index.js` to your project ID.
 
 Run

--- a/config/index.js
+++ b/config/index.js
@@ -9,24 +9,27 @@ var SCOPES = ['https://www.googleapis.com/auth/firebase.remoteconfig'];
 
 /**
  * Get a valid access token.
+ *
+ * This method must be called in either a trusted Google environment like GCP or if running
+ * elsewhere the GOOGLE_APPLICATION_CREDENTIALS environment variable must be set to the path
+ * of the service account credentials file.
  */
 // [START retrieve_access_token]
 function getAccessToken() {
   return new Promise(function(resolve, reject) {
-    var key = require('./service-account.json');
-    var jwtClient = new google.auth.JWT(
-      key.client_email,
-      null,
-      key.private_key,
-      SCOPES,
-      null
-    );
-    jwtClient.authorize(function(err, tokens) {
-      if (err) {
+    google.auth.getApplicationDefault(function (err, authClient) {
+      if (err != null) {
         reject(err);
-        return;
       }
-      resolve(tokens.access_token);
+      if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+        authClient = authClient.createScoped(SCOPES);
+      }
+      authClient.getAccessToken(function(err, token) {
+        if (err != null) {
+          reject(err);
+        }
+        resolve(token);
+      })
     });
   });
 }

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,6 @@
 var rp = require('request-promise');
 var fs = require('fs');
-var google = require('googleapis');
+var {GoogleAuth} = require('google-auth-library');
 
 var PROJECT_ID = 'PROJECT_ID';
 var HOST = 'https://firebaseremoteconfig.googleapis.com';
@@ -16,22 +16,10 @@ var SCOPES = ['https://www.googleapis.com/auth/firebase.remoteconfig'];
  */
 // [START retrieve_access_token]
 function getAccessToken() {
-  return new Promise(function(resolve, reject) {
-    google.auth.getApplicationDefault(function (err, authClient) {
-      if (err != null) {
-        reject(err);
-      }
-      if (authClient.createScopedRequired && authClient.createScopedRequired()) {
-        authClient = authClient.createScoped(SCOPES);
-      }
-      authClient.getAccessToken(function(err, token) {
-        if (err != null) {
-          reject(err);
-        }
-        resolve(token);
-      })
-    });
+  var auth = new GoogleAuth({
+    scopes: SCOPES
   });
+  return auth.getAccessToken();
 }
 // [END retrieve_access_token]
 

--- a/config/package.json
+++ b/config/package.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
-    "google-auth-library": "^0.10.0",
-    "googleapis": "^20.1.0",
-    "request-promise": "^4.2.2",
-    "request": "^2.88.0"
+    "google-auth-library": "^5.3.0",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.2"
   }
 }


### PR DESCRIPTION
Update config quickstart to use default application credential which is best practice for server side Firebase authentication.