### PR TITLE
Set timeout to 10s for RTDB + Firestore emulator tests

### DIFF
--- a/database-emulator/javascript-quickstart/package.json
+++ b/database-emulator/javascript-quickstart/package.json
@@ -4,7 +4,7 @@
   "description": "Real Time Database emulator testing",
   "scripts": {
     "format": "prettier --write **/*.js",
-    "test": "mocha"
+    "test": "mocha --timeout=10000"
   },
   "devDependencies": {
     "@firebase/testing": "0.10.0",

--- a/database-emulator/typescript-quickstart/package.json
+++ b/database-emulator/typescript-quickstart/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "format": "prettier --write **/*.ts",
     "pretest": "tsc",
-    "test": "mocha"
+    "test": "mocha --timeout=10000"
   },
   "devDependencies": {
     "@firebase/testing": "0.10.0",

--- a/firestore-emulator/javascript-quickstart/package.json
+++ b/firestore-emulator/javascript-quickstart/package.json
@@ -4,7 +4,7 @@
   "description": "Cloud Firestore emulator testing",
   "scripts": {
     "format": "prettier --write **/*.js",
-    "test": "mocha"
+    "test": "mocha --timeout=10000"
   },
   "devDependencies": {
     "@firebase/testing": "0.10.0",

--- a/firestore-emulator/typescript-quickstart/package.json
+++ b/firestore-emulator/typescript-quickstart/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "format": "prettier --write **/*.ts",
     "pretest": "tsc",
-    "test": "mocha"
+    "test": "mocha --timeout=10000"
   },
   "devDependencies": {
     "@firebase/testing": "0.10.0",


### PR DESCRIPTION
Fixes https://github.com/firebase/quickstart-nodejs/issues/87