### PR TITLE
false

### DIFF
--- a/firestore-emulator/javascript-quickstart/false
+++ b/firestore-emulator/javascript-quickstart/false
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
rules_version = '2';
service cloud.firestore {
  match /databases/{database}/documents {
    match /{document=**} {
      allow read, write
    }
  }
}