### PR TITLE
Remove old filesystem package

### DIFF
--- a/database-emulator/javascript-quickstart/package.json
+++ b/database-emulator/javascript-quickstart/package.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "@firebase/testing": "^0.15.0",
-    "filesystem": "1.0.1",
     "mocha": "5.2.0",
     "prettier": "1.15.2"
   }

--- a/database-emulator/typescript-quickstart/package.json
+++ b/database-emulator/typescript-quickstart/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "@firebase/testing": "^0.15.0",
     "@types/mocha": "5.2.5",
-    "filesystem": "1.0.1",
     "mocha": "5.2.0",
     "mocha-typescript": "1.1.17",
     "prettier": "1.15.2",

--- a/firestore-emulator/javascript-quickstart/package.json
+++ b/firestore-emulator/javascript-quickstart/package.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "@firebase/testing": "^0.15.0",
-    "filesystem": "1.0.1",
     "mocha": "5.2.0",
     "prettier": "1.15.2"
   }

--- a/firestore-emulator/typescript-quickstart/package.json
+++ b/firestore-emulator/typescript-quickstart/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "@firebase/testing": "^0.15.0",
     "@types/mocha": "5.2.5",
-    "filesystem": "1.0.1",
     "mocha": "5.2.0",
     "mocha-typescript": "1.1.17",
     "prettier": "1.15.2",


### PR DESCRIPTION
[`filesystem`](https://www.npmjs.com/package/filesystem) is an old package that hasn't been updated in 6 years. I'm guessing someone added it thinking it was for `fs`.