### PR TITLE
Update mocha dependencies and replace deprecated mocha.opts

### DIFF
--- a/firestore-emulator/typescript-quickstart/package.json
+++ b/firestore-emulator/typescript-quickstart/package.json
@@ -8,13 +8,18 @@
     "test": "mocha --timeout=10000"
   },
   "devDependencies": {
-    "@firebase/testing": "^0.15.0",
-    "@types/mocha": "5.2.5",
-    "mocha": "5.2.0",
+    "@firebase/testing": "^0.18.2",
+    "@types/mocha": "7.0.2",
+    "mocha": "7.1.1",
     "mocha-typescript": "1.1.17",
-    "prettier": "1.15.2",
-    "source-map-support": "0.5.9",
+    "prettier": "1.19.1",
+    "source-map-support": "0.5.16",
     "ts-node": "7.0.1",
     "typescript": "3.1.3"
+  },
+  "mocha": {
+    "ui": "mocha-typescript",
+    "recursive": "test",
+    "require": "source-map-support/register"
   }
 }

--- a/firestore-emulator/typescript-quickstart/test/mocha.opts
+++ b/firestore-emulator/typescript-quickstart/test/mocha.opts
@@ -1,3 +1,0 @@
---ui mocha-typescript
---require source-map-support/register
---recursive test


### PR DESCRIPTION
Replaces deprecated mocha.opts with package.json entry. Updates mocha dependencies 2 major versions.

Fixes firebase/quickstart-nodejs#117