### PR TITLE
mocha-typescript has been deprecated. we should use @testdeck/mocha.

### DIFF
--- a/firestore-emulator/typescript-quickstart/package.json
+++ b/firestore-emulator/typescript-quickstart/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@firebase/testing": "^0.18.2",
     "@types/mocha": "7.0.2",
+    "@testdeck/mocha": "0.1.0",
     "mocha": "7.1.1",
     "mocha-typescript": "1.1.17",
     "prettier": "1.19.1",
@@ -18,7 +19,6 @@
     "typescript": "3.1.3"
   },
   "mocha": {
-    "ui": "mocha-typescript",
     "recursive": "test",
     "require": "source-map-support/register"
   }

--- a/firestore-emulator/typescript-quickstart/package.json
+++ b/firestore-emulator/typescript-quickstart/package.json
@@ -12,7 +12,6 @@
     "@types/mocha": "7.0.2",
     "@testdeck/mocha": "0.1.0",
     "mocha": "7.1.1",
-    "mocha-typescript": "1.1.17",
     "prettier": "1.19.1",
     "source-map-support": "0.5.16",
     "ts-node": "7.0.1",

--- a/firestore-emulator/typescript-quickstart/test/test.ts
+++ b/firestore-emulator/typescript-quickstart/test/test.ts
@@ -1,6 +1,6 @@
-import * as firebase from '@firebase/testing'
-import { suite, test } from '@testdeck/mocha'
-import * as fs from 'fs'
+import * as firebase from "@firebase/testing";
+import { suite, test } from "@testdeck/mocha";
+import * as fs from "fs";
 
 /*
  * ============
@@ -19,9 +19,7 @@ const rules = fs.readFileSync("firestore.rules", "utf8");
  * @return {object} the app.
  */
 function authedApp(auth) {
-  return firebase
-    .initializeTestApp({ projectId, auth })
-    .firestore();
+  return firebase.initializeTestApp({ projectId, auth }).firestore();
 }
 
 /*

--- a/firestore-emulator/typescript-quickstart/test/test.ts
+++ b/firestore-emulator/typescript-quickstart/test/test.ts
@@ -1,6 +1,6 @@
-/// <reference path='../node_modules/mocha-typescript/globals.d.ts' />
-import * as firebase from "@firebase/testing";
-import * as fs from "fs";
+import * as firebase from '@firebase/testing'
+import { suite, test } from '@testdeck/mocha'
+import * as fs from 'fs'
 
 /*
  * ============


### PR DESCRIPTION
[mocha-typescript](https://www.npmjs.com/package/mocha-typescript) says,
> mocha-typescript has been deprecated, use @testdeck/mocha instead

So, I create migrate PR.