### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,16 +13,16 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 8.x
-          - 10.x
+          - 18.x
+          - 20.x
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache npm
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Use supported versions of Node. Doing this, and updating the `master` branch protection rule to expect Node 18 and 20 instead of 8 and 10, can give us confidence to merge other PRs